### PR TITLE
Allow passing a test case filter to `just run`

### DIFF
--- a/tests/justfile
+++ b/tests/justfile
@@ -1,5 +1,5 @@
-run:
-  cargo run
+run FILTER='':
+  cargo run {{FILTER}}
 
 watch FILTER='':
   cargo watch --debug --clear --exec "run {{FILTER}}"


### PR DESCRIPTION
Allow passing a test case filter to `run` inside the `tests` directory.