### PR TITLE
Add failing multi-line recipe test case

### DIFF
--- a/tests/cases/multi-line-recipe.html
+++ b/tests/cases/multi-line-recipe.html
@@ -1,0 +1,3 @@
+<span class="Function">foo</span><span class="Operator">:</span>
+<span class="Constant">  bar</span>
+<span class="Constant">  baz</span>

--- a/tests/cases/multi-line-recipe.just
+++ b/tests/cases/multi-line-recipe.just
@@ -1,0 +1,3 @@
+foo:
+  bar
+  baz


### PR DESCRIPTION
I noticed that lines after the first aren't being highlighted, so I added a test case that covers this.

Sorry for not actually fixing the bug, I took a look at the syntax file, and it's totally beyond me.

By the way, how did you learn to write syntax files? Is there a good resource I should check out?

Tangent, but syntax file rules remind me of structural regexes:

http://doc.cat-v.org/bell_labs/structural_regexps/se.pdf