### PR TITLE
Add recipe to preview justfile with syntax file from repository

### DIFF
--- a/tests/justfile
+++ b/tests/justfile
@@ -1,11 +1,19 @@
+# run tests
 run FILTER='':
   cargo run {{FILTER}}
 
+# run tests whenever a file changes
 watch FILTER='':
   cargo watch --debug --clear --exec "run {{FILTER}}"
 
+# preview JUSTFILE with syntax file from this repository
+preview JUSTFILE:
+  HOME=`pwd` vim {{JUSTFILE}}
+
+# install rustup (provides `cargo`)
 install-rustup:
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
+# install development dependencies
 deps:
   cargo install cargo-watch


### PR DESCRIPTION
Add a `preview` recipe in `tests/justfile`, that allows previewing a justfile with the syntax file from the repository. Useful during development if you've made some changes and want to see how they look.

This isn't perfect, because it sets `HOME` to get vim to load the syntax file, so it won't load your custom dotfiles, and thus your normal color scheme won't be set.