### PR TITLE
Add (failing) test that multiple dependencies are highlighted correctly

### DIFF
--- a/tests/cases/recipe-multiple-dependencies.html
+++ b/tests/cases/recipe-multiple-dependencies.html
@@ -1,0 +1,1 @@
+<span class="Function">foo</span><span class="Operator">:</span> <span class="Function">bar</span> <span class="Function">baz</span>

--- a/tests/cases/recipe-multiple-dependencies.just
+++ b/tests/cases/recipe-multiple-dependencies.just
@@ -1,0 +1,1 @@
+foo: bar baz


### PR DESCRIPTION
I noticed that dependencies after the first don't seem to be highlighted.