### PR TITLE
Add `.justfile` to ftdetect filenames

### DIFF
--- a/ftdetect/just.vim
+++ b/ftdetect/just.vim
@@ -3,4 +3,4 @@
 " Maintainer:	Noah Bogart <noah.bogart@hey.com>
 " URL:		https://github.com/NoahTheDuke/vim-just.git
 " Last Change:	2021 May 18
-autocmd BufNewFile,BufRead justfile,*.just setfiletype just
+autocmd BufNewFile,BufRead justfile,.justfile,*.just setfiletype just


### PR DESCRIPTION
As of v0.10.0, `just` will find justfiles named `.justfile`, so this PR adds `.justfile` to the ftdetect file.