### PR TITLE
Match filenames case-insenstively.

### DIFF
--- a/ftdetect/just.vim
+++ b/ftdetect/just.vim
@@ -3,4 +3,4 @@
 " Maintainer:	Noah Bogart <noah.bogart@hey.com>
 " URL:		https://github.com/NoahTheDuke/vim-just.git
 " Last Change:	2021 May 18
-autocmd BufNewFile,BufRead justfile,.justfile,*.just setfiletype just
+autocmd BufNewFile,BufRead \cjustfile,.justfile,*.just setfiletype just


### PR DESCRIPTION
I use `Justfile` instead of `justfile`. The `\c` makes matching case-insenstive.