### PR TITLE
Add support for capital-case Justfile

### DIFF
--- a/ftdetect/just.vim
+++ b/ftdetect/just.vim
@@ -3,4 +3,4 @@
 " Maintainer:	Noah Bogart <noah.bogart@hey.com>
 " URL:		https://github.com/NoahTheDuke/vim-just.git
 " Last Change:	2021 May 18
-autocmd BufNewFile,BufRead \cjustfile,.justfile,*.just setfiletype just
+autocmd BufNewFile,BufRead \c[Jj]ustfile,.justfile,*.just setfiletype just

--- a/syntax/just.vim
+++ b/syntax/just.vim
@@ -84,10 +84,10 @@ syntax region justBody transparent matchgroup=justLineLeadingSymbol start="\v^\s
 syntax region justInterpolation start="{{" end="}}" contained contains=ALLBUT,justInterpolation,justFunction,justBodyText
 
 syntax match justBuiltInFunctionParens "[()]" contained
-syntax match justBuiltInFunctions "\v%(arch|os|os_family|invocation_directory|justfile|justfile_directory|just_executable)\ze\(\)" contains=justBuiltInFunctions
+syntax match justBuiltInFunctions "\v%(arch|os|os_family|invocation_directory|[Jj]ustfile|justfile_directory|just_executable)\ze\(\)" contains=justBuiltInFunctions
 syntax region justBuiltInFunctions transparent matchgroup=justBuiltInFunctions start="\v%(env_var_or_default|env_var)\ze\(" end=")" oneline contains=@justAllStrings,justBuiltInFunctionParens,justNoise
 
-syntax match justBuiltInFunctionsError "\v%(arch|os|os_family|invocation_directory|justfile|justfile_directory|just_executable)\(.+\)"
+syntax match justBuiltInFunctionsError "\v%(arch|os|os_family|invocation_directory|[Jj]ustfile|justfile_directory|just_executable)\(.+\)"
 
 syntax match justOperator "\v%(\=\=|!\=|\+)"
 


### PR DESCRIPTION
Currently, capital-case `Justfile` files are not syntax-highlighted.
This attempts to address that.