### PR TITLE
Set the commentstring option to `# `

### DIFF
--- a/after/ftplugin/just.vim
+++ b/after/ftplugin/just.vim
@@ -5,3 +5,4 @@
 " Last Change:	2021 May 19
 
 setlocal iskeyword+=-
+setlocal commentstring=#\ %s


### PR DESCRIPTION
When opening justfiles with vim-just loaded, my vim had the `commentstring` option set to `/*%s*/` instead of `#\ %s`, so commenting with vim-commentary did not work properly.