### PR TITLE
Overhaul and expand preview functionality

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,40 @@
+# Do not prevent local external justfile recipes from being run from cwd within the repo
+set fallback
+
+rq := quote(justfile_directory())
+
+synpreview_homedir := env_var_or_default('TMPDIR', '/tmp') / '_vim-just-preview-home.' + replace(uuid(), '-', '')
+
+# preview JUSTFILE in Vim with syntax file from this repository
+[no-cd]
+preview JUSTFILE='': _vim_preview_home && _clean_vim_preview_home
+	HOME={{quote(synpreview_homedir)}} \
+	  vim {{if JUSTFILE == '' { '-c "set filetype=just"' } else { quote(JUSTFILE) } }}
+
+# preview JUSTFILE in GVim with syntax file from this repository
+[no-cd]
+gpreview JUSTFILE='': _vim_preview_home && _clean_vim_preview_home
+	HOME={{quote(synpreview_homedir)}} \
+	  gvim -f {{if JUSTFILE == '' { '-c "set filetype=just"' } else { quote(JUSTFILE) } }}
+
+# preview JUSTFILE in Neovim with syntax file from this repository
+[no-cd]
+npreview JUSTFILE='': && _clean_vim_preview_home
+	#!/bin/bash
+	mkdir -p {{quote(synpreview_homedir / '.config/nvim/pack/just/start')}}
+	ln -s {{rq}} {{quote(synpreview_homedir / '.config/nvim/pack/just/start/vim-just')}}
+	for c in ${XDG_CONFIG_HOME:-$HOME/.config}/nvim/{colors,init.vim};do \
+	  test -e "$c" && ln -vs "$c" {{quote(synpreview_homedir / '.config/nvim')}}; \
+	done
+	HOME={{quote(synpreview_homedir)}} XDG_CONFIG_HOME={{quote(synpreview_homedir / '.config')}} \
+	  nvim -c 'syntax on' \
+	    {{if JUSTFILE == '' { '-c "set filetype=just"' } else { quote(JUSTFILE) } }}
+
+_vim_preview_home: _clean_vim_preview_home
+	mkdir -p {{quote(synpreview_homedir / '.vim/pack/just/start')}}
+	ln -s {{rq}} {{quote(synpreview_homedir / '.vim/pack/just/start/vim-just')}}
+	for c in ~/.vim/colors ~/.vim/vimrc ~/.vim/gvimrc;do \
+	  test -e "$c" && ln -vs "$c" {{quote(synpreview_homedir / '.vim')}}; \
+	done
+_clean_vim_preview_home:
+	rm -fvR {{quote(synpreview_homedir)}}

--- a/justfile
+++ b/justfile
@@ -25,11 +25,20 @@ gpreview JUSTFILE='': _vim_preview_home && _clean_vim_preview_home
 npreview JUSTFILE='': && _clean_vim_preview_home
 	#!/bin/bash
 	mkdir -p {{quote(synpreview_homedir / '.config/nvim/pack/just/start')}}
+	mkdir -p {{quote(synpreview_homedir / '.local/share/nvim/site/pack')}}
 	ln -s {{rq}} {{quote(synpreview_homedir / '.config/nvim/pack/just/start/vim-just')}}
-	for c in ${XDG_CONFIG_HOME:-$HOME/.config}/nvim/{colors,init.vim};do \
+	for c in ${XDG_CONFIG_HOME:-$HOME/.config}/nvim/{colors,init.vim,init.lua,lua,plugin};do \
 	  test -e "$c" && ln -vs "$c" {{quote(synpreview_homedir / '.config/nvim')}}; \
 	done
-	HOME={{quote(synpreview_homedir)}} XDG_CONFIG_HOME={{quote(synpreview_homedir / '.config')}} \
+	for c in ${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/pack/packer;do
+	  # copy instead of symlink in case we will remove an existing copy of vim-just
+	  test -e "$c" && cp -pvR "$c" {{quote(synpreview_homedir / '.local/share/nvim/site/pack')}};
+	done
+	# remove any existing installation of vim-just from the temporary home
+	find {{quote(synpreview_homedir / '.local/share')}} -iname vim-just -exec rm -fvR {} +
+	HOME={{quote(synpreview_homedir)}} \
+	  XDG_CONFIG_HOME={{quote(synpreview_homedir / '.config')}} \
+	  XDG_DATA_HOME={{quote(synpreview_homedir / '.local/share')}} \
 	  nvim -c 'syntax on' \
 	    {{if JUSTFILE == '' { '-c "set filetype=just"' } else { quote(JUSTFILE) } }}
 

--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ rq := quote(justfile_directory())
 
 synpreview_homedir := env_var_or_default('TMPDIR', '/tmp') / '_vim-just-preview-home.' + replace(uuid(), '-', '')
 
+@_default:
+	just --list
+
 # preview JUSTFILE in Vim with syntax file from this repository
 [no-cd]
 preview JUSTFILE='': _vim_preview_home && _clean_vim_preview_home

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,3 +1,6 @@
+# To enable using preview recipes from cwd inside tests/
+set fallback
+
 # run tests
 run FILTER='':
   cargo run {{FILTER}}
@@ -9,10 +12,6 @@ watch FILTER='':
     --debug \
     --exec "run {{FILTER}}" \
     --watch ..
-
-# preview JUSTFILE with syntax file from this repository
-preview JUSTFILE:
-  HOME=`pwd` vim {{JUSTFILE}}
 
 # install rustup (provides `cargo`)
 install-rustup:


### PR DESCRIPTION
 - Decouple preview from tests
 - Add recipes to preview in GVim and Neovim
 - It is now possible to specify the justfile to preview by path relative to cwd
 - It is no longer required to preview a specific justfile.  If no justfile is specified, Vim/GVim/Neovim will be started with `set filetype=just` pre-set.
 - Preserve some partial user configuration, including color schemes.

Resolves https://github.com/NoahTheDuke/vim-just/issues/32

@NoahTheDuke as you actually use Neovim, could you please review the Neovim preview recipe before this is merged?  Thanks :slightly_smiling_face: 