### PR TITLE
Fix consistency issues joining comments

### DIFF
--- a/ftplugin/just.vim
+++ b/ftplugin/just.vim
@@ -11,6 +11,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal iskeyword+=-
+setlocal comments=n:#
 setlocal commentstring=#\ %s
 
-let b:undo_ftplugin = "setlocal iskeyword< commentstring<"
+let b:undo_ftplugin = "setlocal iskeyword< comments< commentstring<"


### PR DESCRIPTION
For example, a justfile containing this -
```
# test
# test2
#test3
```
(and `:set formatoptions=qj` set in Vim)

Put cursor at the first line and hit `Shift+J`.  Notice that joining the first two comments removes what was the leading `#` of the second comment.  But hit `Shift+J` again, to join the third comment too, and this time the "extra" `#` remains.

Per `:help format-comments`, it was kinda coincidence that this was working at all -
> By default, "b:#" is included.

So this patch sets `comments` explicitly and better tailored to `just` comments.

(Proposing this patch as a PR because I'm not well versed in Vim ftplugins, I only just found out about this option yesterday.)