### PR TITLE
Document installing with lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ cd ~/.vim/pack/YOUR-NAMESPACE-HERE/start/
 git clone https://github.com/NoahTheDuke/vim-just.git
 ```
 
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "NoahTheDuke/vim-just",
+  event = { "BufReadPre", "BufNewFile" },
+  ft = { "\\cjustfile", "*.just", ".justfile" },
+}
+```
+
 ----------
 
 ### Updating `git clone` based installations


### PR DESCRIPTION
Updates README to provide a bit of guidance for installing vim-just with lazy.nvim. Based on resolution for https://github.com/NoahTheDuke/vim-just/issues/47
