### PR TITLE
Reorganize and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,6 @@ Vim syntax files for [justfiles](https://github.com/casey/just).
 
 ## Installation
 
-### [vim-plug](https://github.com/junegunn/vim-plug)
-
-```vim
-Plug 'NoahTheDuke/vim-just'
-```
-
-### [Pathogen](https://github.com/tpope/vim-pathogen)
-
-```bash
-cd ~/.vim/bundle
-git clone https://github.com/NoahTheDuke/vim-just.git
-```
-
 ### [Vim8 Package](https://vimhelp.org/repeat.txt.html#packages)
 
 ```bash
@@ -24,15 +11,28 @@ cd ~/.vim/pack/YOUR-NAMESPACE-HERE/start/
 git clone https://github.com/NoahTheDuke/vim-just.git
 ```
 
-### [lazy.nvim](https://github.com/folke/lazy.nvim)
+### With a plugin manager
+
+#### [vim-plug](https://github.com/junegunn/vim-plug)
+
+```vim
+Plug 'NoahTheDuke/vim-just'
+```
+
+#### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 {
   "NoahTheDuke/vim-just",
-  event = { "BufReadPre", "BufNewFile" },
-  ft = { "\\cjustfile", "*.just", ".justfile" },
+  ft = { "just" },
 }
 ```
+
+### Third-party packages
+
+For questions or issues when using these packages, contact the package's maintainer.
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/vim:vim-just.svg)](https://repology.org/project/vim:vim-just/versions)
 
 ----------
 


### PR DESCRIPTION
- Update lazy.nvim installation instructions for current lazy.nvim.  Our ftdetect changed since then and the existing instructions were no longer working consistently for me.
- Remove Pathogen installation instructions, Pathogen [is officially dead for more than a year now](https://github.com/tpope/vim-pathogen/pull/223#issuecomment-1226015841).
- Promote Vim8 Package and use a dedicated subsection for plugin manager based installations:
  - Since Vim8 Package is built into Vim/Neovim, it's in a different category.  And in the absence of a plugin manager, Vim8 Package would be the simplest installation method.
  - The previous organization looked like we specifically support all listed plugin managers.  If we add more plugin managers instructions in future, we may want to add "Community-contributed installation instructions" in some form, to provide the helpful information for users without committing to supporting too many additional plugin managers.  That would fit better in this organization.
- Add Repology badge to list third-party packages.  Apparently Repology knows about this project now thanks to https://github.com/NixOS/nixpkgs/pull/235765