### PR TITLE
tests: enable `clippy::get_unwrap` lint

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,9 @@ default-run = "tests"
 name = "test-ftdetect"
 path = "src/test-ftdetect.rs"
 
+[lints.clippy]
+get_unwrap = "warn"
+
 [dependencies]
 clap         = { version = "4.5.4", features = ["derive"] }
 ctrlc        = "3.4.4"


### PR DESCRIPTION
Going through our test runner code, I noticed I had written code that follows this pattern -
```rust
let h = HashMap::<String, String>::new();
let _ = h.get("foo").unwrap();
```
But the second line can use `&h["foo"]` for equivalent behavior, clearer code, and a more informative error message if that key unexpectedly doesn't exist.  I've already changed our code to use this clearer style, but I was like, wait why didn't Clippy warn about this?

Turns out the answer is, there is such Clippy lint, but it's allow-by-default.

This PR makes `.get(...).unwrap()` a Clippy warning, i.e. it's fine in dev (e.g. temporarily using `.unwrap()` where error handling will be added later) but we don't want code like this in production.