### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ For questions or issues when using these packages, contact the package's maintai
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/vim:vim-just.svg)](https://repology.org/project/vim:vim-just/versions)
 
+## Using alongside `nvim-treesitter`
+
+If `nvim-treesitter` is installed and has a justfile language parser available,
+`nvim-treesitter` will overrule `vim-just` by default.
+
+To use `vim-just` syntax highlighting with other `nvim-treesitter` features,
+configure `nvim-treesitter` not to use its justfile language parser for syntax highlighting:
+
+```lua
+require("nvim-treesitter.configs").setup({
+  highlight = {
+    enable = true,
+    disable = { "just" },
+  },
+})
+```
+
+For more details or more complex configurations, see
+[nvim-treesitter documentation](https://github.com/nvim-treesitter/nvim-treesitter#modules).
+
 ## Migrating old `git clone` based installations to `main`
 
 In late March 2023, development was moved from `master` branch to `main` branch,


### PR DESCRIPTION
- Minor reorganization to better accommodate note about using both `vim-just` and `nvim-treesitter` at the same time.  Also remove instructions to use `--tags` flag to update `git clone` based installations, we never did tag anything and future tagging currently seems unlikely.
- Document that `nvim-treesitter` overrules `vim-just` by default, and how to use `vim-just` syntax highlighting with `nvim-treesitter` providing other features for justfiles.  This combination seems to be desirable for some users, so let's help them avoid confusion that ends in reporting `tree-sitter-just` bugs here thinking it's `vim-just` issues.

Tag https://github.com/NoahTheDuke/vim-just/issues/97#issuecomment-2171685742