### PR TITLE
ci: pin to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
   all:
     name: All
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       RUSTFLAGS: "--deny warnings"


### PR DESCRIPTION
Tag https://github.com/NoahTheDuke/vim-just/issues/103

Testing that CI passes and is still using the same image