### PR TITLE
Switch from `cargo-watch` to `watchexec-cli`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ is a simple test-runner in the `main` fn.
 * Rust ([simple/recommended installation instructions](https://www.rust-lang.org/tools/install); for detailed and alternative installation instructions see [here](https://forge.rust-lang.org/infra/other-installation-methods.html))
 
 Run `just deps` to install the cargo dev dependencies, which right now is only
-[`cargo-watch`](https://crates.io/crates/cargo-watch).
+[Watchexec CLI](https://crates.io/crates/watchexec-cli).
 
 ### Running the tests
 
@@ -80,7 +80,7 @@ To run the filetype detection tests, run `just ftdetect` in tests/.
 If you're going to do more than a simple change, I recommend calling `just watch` in tests/,
 which will watch for any changes in the whole repo and re-run the test suite.
 By default, it will run the syntax highlighting tests.
-`just watch` accepts up to two parameters to customize which tests to watch:
+`just watch` accepts positional parameters to customize which tests to watch:
 
 ```bash
 # watch all syntax highlighting tests (default)

--- a/tests/justfile
+++ b/tests/justfile
@@ -14,17 +14,16 @@ cases_invalid_justfiles := """
 run FILTER='':
   cargo run {{ if FILTER == '' { '' } else { '-- ' + quote(FILTER) } }}
 
-watchwatch := '`just watch watch` is redundant'
-
 # run tests whenever a file changes
-watch RECIPE='run' FILTER='': build
-  cargo watch \
+[positional-arguments]
+watch *args:
+  {{if args =~ '(?:^|\s)watch(?:\s|$)' { error('`just watch watch` is redundant') } else { '' } }}
+  watchexec \
     --clear \
-    --shell "{{quote(just_executable())}} \
-        {{if RECIPE == 'watch' { error(watchwatch) } else { quote(RECIPE) } }} \
-        {{if RECIPE + FILTER =~ 'watch' { error(watchwatch) } else if FILTER == '' { '' } else { quote(FILTER) } }} \
-      " \
-    --watch ..
+    --shell=none \
+    --project-origin {{quote(clean(source_directory() / '..'))}} \
+    --watch {{quote(clean(source_directory() / '..'))}} \
+    {{quote(just_executable())}} "$@"
 
 # run ftdetect tests
 ftdetect:
@@ -32,7 +31,7 @@ ftdetect:
 
 # install development dependencies
 deps:
-  cargo install --locked cargo-watch
+  cargo install watchexec-cli
 
 # compile test runner without running tests
 build:


### PR DESCRIPTION
Closes https://github.com/NoahTheDuke/vim-just/issues/112

Also with this change removed `watch` dependency on `build`.  I don't remember why I added that in the first place, but with `watchexec` and our current test runner, this dependency doesn't seem necessary anymore.

@NoahTheDuke Proposing this as PR to be sure you're OK with using `watchexec-cli` before pushing this to main?