### PR TITLE
Bring in patch to ensure required Vim syntaxes are enabled

### DIFF
--- a/syntax/just.vim
+++ b/syntax/just.vim
@@ -10,6 +10,12 @@ endif
 
 let b:current_syntax = 'just'
 
+" Ensure the Vim syntaxes required by this file are enabled.
+" Setting and restoring 'cpoptions' is documented not to have side effects,
+" so this does not need to be conditionally gated.
+let s:cpo_save = &cpo
+set cpo&vim
+
 " syncing fromstart prevents mismatched highlighting when jumping around in a justfile
 " linebreaks= keeps multi-line constructs highlighted correctly while typing
 syn sync fromstart linebreaks=10
@@ -320,6 +326,10 @@ syn match justModStatement '^mod' contained
 
 syn match justOptionalFile '\V?' contained
 
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
 " Most linked colorscheme colors are chosen based on semantics of the color name.
 " Some are for parity with other syntax files (for example, Number for recipe body highlighting
 " is to align with the make.vim distributed with Vim).
@@ -330,7 +340,8 @@ syn match justOptionalFile '\V?' contained
 "
 " Note that vim-just's highlight groups are an implementation detail and may be subject to change.
 
-" The list of highlight links is sorted alphabetically.
+" The list of highlight links is sorted alphabetically,
+" and is placed at the very end of the file to simplify keeping it sorted.
 
 hi def link justAlias                            Statement
 hi def link justAssignmentOperator               Operator


### PR DESCRIPTION
This PR brings https://github.com/vim/vim/pull/16466/commits/61fd27032e2bba6ecea1d1baadf1d8dbbe88b649#diff-a43cea7603144b91369f5717ea0d128a0dd09242dfb2eec713ecc12eaa8d15cc upstream:

`vim-just` makes extensive use of Vim syntaxes that require part of the effect of `set nocompatible`.  And even with Vim configurations that do `set nocompatible`, I have seen cases where some syntax files get loaded before the `set nocompatible` is applied, resulting in very obscure, hard-to-diagnose errors.

This patch fixes `vim-just` to work even when user's Vim config outright does `set compatible`.  It should not affect user's Vim setup and this method does not have side effects.

Ping @pbnj as original author of this patch (I only added comments and minor reorganization) - hope the way of crediting you in the commit message is OK with you, if you would like something different please let us know.