### PR TITLE
Highlight the Android recipe attribute

### DIFF
--- a/syntax/just.vim
+++ b/syntax/just.vim
@@ -109,7 +109,7 @@ syn region justRecipeAttributes
    \ contains=justRecipeAttr,justRecipeAttrSep,justRecipeAttrArgs,justRecipeAttrArgError,justRecipeAttrValueShort
 
 syn keyword justRecipeAttr
-   \ arg confirm default doc exit-message extension group linux macos metadata no-cd no-exit-message no-quiet openbsd parallel positional-arguments private script unix windows working-directory
+   \ android arg confirm default doc exit-message extension group linux macos metadata no-cd no-exit-message no-quiet openbsd parallel positional-arguments private script unix windows working-directory
    \ contained
 syn match justRecipeAttrSep ',' contained
 syn match justRecipeAttrValueShort '\v:%(\_s|\\\n)*' transparent contained

--- a/tests/cases/recipes-with-extras.html
+++ b/tests/cases/recipes-with-extras.html
@@ -48,6 +48,10 @@ param <span class="Operator">:=</span> <span class="Function">semver_matches</sp
 <span class="Function">error</span><span class="Operator">:</span>
 <span class="Number">&Tab;sh -c </span><span class="String">'echo Exit 3;exit 3'</span>
 
+<span class="Type">[android]</span>
+<span class="Function">android-only</span><span class="Operator">:</span>
+<span class="Number">&Tab;echo android</span>
+
 <span class="Type">[</span> <span class="Type">unix</span> <span class="Type">]</span>
 <span class="Type">[</span>  <span class="Type">macos</span><span class="Operator">,</span><span class="Type">windows</span><span class="Operator">,</span> <span class="Type">linux</span> <span class="Type">]</span>
 <span class="Function">any</span><span class="Operator">:</span>

--- a/tests/cases/recipes-with-extras.just
+++ b/tests/cases/recipes-with-extras.just
@@ -48,6 +48,10 @@ runpwd:
 error:
 	sh -c 'echo Exit 3;exit 3'
 
+[android]
+android-only:
+	echo android
+
 [ unix ]
 [  macos,windows, linux ]
 any:


### PR DESCRIPTION
## Summary

- recognize `[android]` as a recipe attribute
- cover an Android-only recipe in the existing syntax fixture
- update the expected HTML highlighting snapshot

## Rationale

`just` added the `[android]` recipe attribute in upstream commit `6d2173e`. Without this keyword, Vim and Neovim leave `android` in the transparent attribute region instead of highlighting it like the other supported platform attributes.

This addresses the `[android]` item in #131 without changing the other syntax additions tracked there.

## Verification

- all 15 syntax snapshots matched under Vim 9.1
- all 15 syntax snapshots matched under Neovim 0.12.4
- focused before/after checks changed the `android` token from the transparent attribute region to the linked `Type` group in both editors
- `just` 1.56.0 parsed the updated fixture and the remaining compatible valid fixtures
- `git diff --check`
